### PR TITLE
Feature/#16079 implement file return listener in http service

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,13 +569,17 @@ Keep in mind that header keys will be in lower case.
 The field `requestInfo` contains this information:
 
 - `method`: it is the HTTP verb, like `POST`, `GET`, etc.
-- `url`: the full URL of the request, like `https://app.slingrs.io/prod/svc/http`.
+- `url`: the full URL of the request, like `https://app.slingrs.io/prod/services/http`.
 - `encoding`: encoding of the request, like `UTF-8`.
 
 Keep in mind that the service will just respond with `200` status code with `ok` as the body, and 
 you won't be able to provide a custom response.
 
 ### Sync Webhooks
+
+- `method`: it is the HTTP verb, like `POST`, `GET`, etc.
+- `url`: the full URL of the request, like `https://app.slingrs.io/prod/services/http/sync`.
+- `encoding`: encoding of the request, like `UTF-8`.
 
 This works exactly the same as the regular webhooks with the only difference that you can return
 the response from the listener that process the webhook. For example, the listener could be like
@@ -587,6 +591,27 @@ var res = {
     date: new Date()
 };
 return res;
+```
+
+Keep in mind that the response should be a valid JSON.
+
+### Download Files from the application
+
+- `method`: `GET`.
+- `url`: the full URL of the request, like `https://app.slingrs.io/prod/services/http/download/<some-path-query>`.
+- `encoding`: encoding of the request, like `UTF-8`.
+
+This works exactly the same as the regular webhooks with the only difference that you can return
+the fileId and fileName of one file to download from the browser:
+
+```js
+  sys.context.setCurrentUserRecord(sys.data.findOne("sys.users", {email: "usuario123@test.com"}))
+  let user = sys.context.getCurrentUserRecord();
+    // the field "file" is of type File
+  return {
+      fileId: user.field("file").val().id, 
+      fileName: user.field("file").val().name
+  }
 ```
 
 Keep in mind that the response should be a valid JSON.

--- a/appService.json
+++ b/appService.json
@@ -27,12 +27,17 @@
         {
             "label": "Webhook Sync",
             "name": "webhookSync",
-            "description": "Happens when a HTTP request hits the service URL and needs a response from the listener. Must be a POST with content type application/json."
+            "description": "Happens when a async HTTP request hits the service URL and needs a response from the listener. Must be a POST with content type application/json."
         },
         {
             "label": "File Downloaded",
             "name": "fileDownloaded",
             "description": "Happens when a async download file process is finished (thrown by a GET function with 'forceDownload' enabled and 'downloadSync' disabled)"
+        },
+        {
+            "label": "Download File",
+            "name": "downloadFile",
+            "description": "Happens when a async HTTP request hits the service URL and needs a response from the listener with the file content."
         }
     ],
     "functions": [

--- a/appService.json
+++ b/appService.json
@@ -30,12 +30,12 @@
             "description": "Happens when a async HTTP request hits the service URL and needs a response from the listener. Must be a POST with content type application/json."
         },
         {
-            "label": "File Downloaded",
+            "label": "File Downloaded from external URL",
             "name": "fileDownloaded",
             "description": "Happens when a async download file process is finished (thrown by a GET function with 'forceDownload' enabled and 'downloadSync' disabled)"
         },
         {
-            "label": "Download File",
+            "label": "Download File from App",
             "name": "downloadFile",
             "description": "Happens when a async HTTP request hits the service URL and needs a response from the listener with the file content."
         }

--- a/src/main/java/io/slingr/service/http/Http.java
+++ b/src/main/java/io/slingr/service/http/Http.java
@@ -138,9 +138,15 @@ public class Http extends HttpService {
                     buffer.flush();
                     byte[] fileBytes = buffer.toByteArray();
                     Json headers = downloadedFile.getHeaders();
-                    headers.set("Content-Type", "application/octet-stream");
-                    headers.set("Content-Disposition", "attachment; filename=\"" + (options.contains("fileName") ? options.string("fileName") : (fileMetadata.contains("fileName") ? fileMetadata.string("fileName") : "file")) + "\"");
-                    return new WebServiceResponse(fileBytes, ContentType.APPLICATION_OCTET_STREAM.toString());
+                    headers.set("Content-Type", fileMetadata.contains("contentType") ? fileMetadata.string("contentType") : "application/octet-stream");
+                    headers.set("Content-Length", fileMetadata.contains("length") ? fileMetadata.string("length") : null);
+                    String fileName = options.contains("fileName") ?
+                            options.string("fileName").split(" ")[0] :
+                            (fileMetadata.contains("fileName") ?
+                                    fileMetadata.string("fileName") :
+                                    "file");
+                    headers.set("Content-Disposition", "attachment; filename=\"" + fileName + "\"");
+                    return new WebServiceResponse(200, fileBytes, headers);
                 }
             }
             return new WebServiceResponse(404, Json.map(), ContentType.APPLICATION_JSON.toString());

--- a/src/main/java/io/slingr/service/http/Http.java
+++ b/src/main/java/io/slingr/service/http/Http.java
@@ -6,6 +6,8 @@ import io.slingr.services.exceptions.ErrorCode;
 import io.slingr.services.exceptions.ServiceException;
 import io.slingr.services.framework.annotations.*;
 import io.slingr.services.services.AppLogs;
+import io.slingr.services.services.rest.DownloadedFile;
+import io.slingr.services.services.rest.RestMethod;
 import io.slingr.services.utils.Json;
 import io.slingr.services.ws.exchange.WebServiceRequest;
 import io.slingr.services.ws.exchange.WebServiceResponse;
@@ -13,6 +15,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.http.entity.ContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
 
 import static io.slingr.services.services.HttpService.defaultWebhookConverter;
 
@@ -96,17 +101,54 @@ public class Http extends HttpService {
         return new WebServiceResponse(Json.map(), ContentType.APPLICATION_JSON.toString());
     }
 
-    @ServiceWebService(path = "{externalService}/sync")
-    public WebServiceResponse optionsLoad(WebServiceRequest request) {
+    @ServiceWebService(path = "/sync/{externalService}")
+    public WebServiceResponse syncWebhook(WebServiceRequest request) {
         logger.info(String.format("Webhook sync received for service [%s]", SERVICE_NAME));
         try {
-            Json options = (Json) events().sendSync("webhookSync", defaultWebhookConverter(request));
+            Json webhookConverted = defaultWebhookConverter(request);
+            webhookConverted.set("path", request.getPath().replace("/sync", ""));
+            Json options = (Json) events().sendSync("webhookSync", webhookConverted);
             return new WebServiceResponse(options, ContentType.APPLICATION_JSON.toString());
         } catch (ClassCastException cce) {
             appLogs.error("The response to the sync webhook from the listener is not a valid JSON");
         } catch (Exception e) {
             appLogs.error("There was an error processing sync webhook: " + e.getMessage(), e);
         }
-        return new WebServiceResponse(Json.map(), ContentType.APPLICATION_JSON.toString());
+        return new WebServiceResponse(500, Json.map(), ContentType.APPLICATION_JSON.toString());
+    }
+
+    @ServiceWebService(path = "/download/{fileId}", methods = {RestMethod.GET})
+    public WebServiceResponse downloadFile(WebServiceRequest request) {
+        logger.info(String.format("Webhook sync for download file received, for service [%s]", SERVICE_NAME));
+        try {
+            Json webhookConverted = defaultWebhookConverter(request);
+            webhookConverted.set("path", request.getPath().replace("/download", ""));
+            Json options = (Json) events().sendSync("downloadFile", webhookConverted);
+            if (options != null) {
+                if (options.contains("fileId") && options.string("fileId") != null) {
+                    Json fileMetadata = files().metadata(options.string("fileId"));
+                    DownloadedFile downloadedFile = files().download(options.string("fileId"));
+                    InputStream file = downloadedFile.getFile();
+                    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+                    int nRead;
+                    byte[] data = new byte[1024];
+                    while ((nRead = file.read(data, 0, data.length)) != -1) {
+                        buffer.write(data, 0, nRead);
+                    }
+                    buffer.flush();
+                    byte[] fileBytes = buffer.toByteArray();
+                    Json headers = downloadedFile.getHeaders();
+                    headers.set("Content-Type", "application/octet-stream");
+                    headers.set("Content-Disposition", "attachment; filename=\"" + (options.contains("fileName") ? options.string("fileName") : (fileMetadata.contains("fileName") ? fileMetadata.string("fileName") : "file")) + "\"");
+                    return new WebServiceResponse(fileBytes, ContentType.APPLICATION_OCTET_STREAM.toString());
+                }
+            }
+            return new WebServiceResponse(404, Json.map(), ContentType.APPLICATION_JSON.toString());
+        } catch (ClassCastException cce) {
+            appLogs.error("The response to the sync webhook from the listener is not a valid JSON");
+        } catch (Exception e) {
+            appLogs.error("There was an error processing sync webhook: " + e.getMessage(), e);
+        }
+        return new WebServiceResponse(500, Json.map(), ContentType.APPLICATION_JSON.toString());
     }
 }


### PR DESCRIPTION
Pull-request for issue #16079 created by @pasaperez-slingr

## What it does?

Add a web service to be able to handle the syncronic event of downloading a file through the service.


## How to test it?

This event can be tested in idea2 with the listener configured in test1. 

https://test1.idea2.io/dev/services/http/download/65f46deef8150a055a757686 (<- this id could be any query path, the user customize it)

The event can be configured from scripts so what is received in the http parameter can be custom and what is returned as well. 

![image](https://github.com/slingr-stack/http-service/assets/119679724/f2437bbf-8a2c-4f0d-b6c8-0d165571434b)

In this example we only added a Field type file called file in which the user admin@test.com uploaded an image.

```js
  sys.context.setCurrentUserRecord(sys.data.findOne("sys.users", {email: "admin@test.com"}))
  let user = sys.context.getCurrentUserRecord();
  return {fileId: user.field("file").val().id, fileName: user.field("file").val().name}
```

Remember to use this [checklist](https://docs.google.com/document/d/139rKhIsvpT3yBSB88BBZfy03fD_Sried0bVwIWVaHJk/edit?usp=sharing) for the review.

## Technical notes

There are no technical notes.

## Deployment notes

There are no deployment notes.